### PR TITLE
Add `serve` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Note that, if the `output` configuration is not set, it will automatically be
 generated to write bundles in the `.webpack` directory.
 
 ## Usage
+
 ### Automatic bundling
 
 The normal Serverless deploy procedure will automatically bundle with Webpack:
@@ -36,6 +37,20 @@ The normal Serverless deploy procedure will automatically bundle with Webpack:
 - Create the Serverless project with `serverless create -t aws-node`
 - Install Serverless Webpack as above
 - Deploy with `serverless deploy`
+
+### Simulate API Gateway locally
+
+To start a local server that will act like the API Gateway use the following command.
+Your code will be reloaded upon change so that every request to your local server
+will serve the latest code.
+
+```
+serverless webpack serve
+```
+
+Options are:
+
+- `--port` or `-p` (optional) The local server port. Defaults to `8000`
 
 ### Run a function locally
 

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const validate = require('./lib/validate');
 const compile = require('./lib/compile');
 const cleanup = require('./lib/cleanup');
 const run = require('./lib/run');
+const serve = require('./lib/serve');
 
 class ServerlessWebpack {
   constructor(serverless, options) {
@@ -17,7 +18,8 @@ class ServerlessWebpack {
       validate,
       compile,
       cleanup,
-      run
+      run,
+      serve
     );
 
     this.commands = {
@@ -68,6 +70,18 @@ class ServerlessWebpack {
               },
             },
           },
+          serve: {
+            usage: 'Simulate the API Gateway and serves lambdas locally',
+            lifecycleEvents: [
+              'serve',
+            ],
+            options: {
+              port: {
+                usage: 'The local server port',
+                shortcut: 'p',
+              },
+            },
+          },
         },
       },
     };
@@ -95,6 +109,10 @@ class ServerlessWebpack {
       'webpack:watch:watch': () => BbPromise.bind(this)
         .then(this.validate)
         .then(this.watch),
+
+      'webpack:serve:serve': () => BbPromise.bind(this)
+        .then(this.validate)
+        .then(this.serve),
     };
   }
 }

--- a/lib/run.js
+++ b/lib/run.js
@@ -3,18 +3,16 @@
 const BbPromise = require('bluebird');
 const path = require('path');
 const webpack = require('webpack');
+const utils = require('./utils');
 
 module.exports = {
-  loadFunction(stats) {
-    const functionName = this.options.function;
+  loadHandler(stats) {
     const handlerFilePath = path.join(
       stats.compilation.options.output.path,
       stats.compilation.options.output.filename
     );
-    purgeCache(handlerFilePath);
-    const handler = require(handlerFilePath);
-
-    return handler[functionName];
+    utils.purgeCache(handlerFilePath);
+    return require(handlerFilePath);
   },
 
   getEvent() {
@@ -23,11 +21,10 @@ module.exports = {
       : null; // TODO use get-stdin instead
   },
 
-  getContext() {
-    const functionName = this.options.function;
+  getContext(functionName) {
     return {
-      awsRequestId: guid(),
-      invokeid: guid(),
+      awsRequestId: utils.guid(),
+      invokeid: utils.guid(),
       logGroupName: `/aws/lambda/${functionName}`,
       logStreamName: '2016/02/14/[HEAD]13370a84ca4ed8b77c427af260',
       functionVersion: '$LATEST',
@@ -42,9 +39,9 @@ module.exports = {
 
     this.serverless.cli.log(`Run function ${functionName}...`);
 
-    const handler = this.loadFunction(stats);
+    const handler = this.loadHandler(stats)[functionName];
     const event = this.getEvent();
-    const context = this.getContext();
+    const context = this.getContext(functionName);
 
     return new BbPromise((resolve, reject) => handler(
       event,
@@ -70,9 +67,9 @@ module.exports = {
         throw err;
       }
       this.serverless.cli.log(`Run function ${functionName}...`);
-      const handler = this.loadFunction(stats);
+      const handler = this.loadHandler(stats)[functionName];
       const event = this.getEvent();
-      const context = this.getContext();
+      const context = this.getContext(functionName);
       handler(
         event,
         context,
@@ -89,35 +86,3 @@ module.exports = {
     return BbPromise.resolve();
   },
 };
-
-function guid() {
-  function s4() {
-    return Math.floor((1 + Math.random()) * 0x10000)
-      .toString(16)
-      .substring(1);
-  }
-  return s4() + s4() + '-' + s4() + '-' + s4() + '-' + s4() + '-' + s4() + s4() + s4();
-}
-
-function purgeCache(moduleName) {
-  searchCache(moduleName, function (mod) {
-    delete require.cache[mod.id];
-  });
-  Object.keys(module.constructor._pathCache).forEach(function(cacheKey) {
-    if (cacheKey.indexOf(moduleName)>0) {
-     delete module.constructor._pathCache[cacheKey];
-    }
-  });
-}
-
-function searchCache(moduleName, callback) {
-  var mod = require.resolve(moduleName);
-  if (mod && ((mod = require.cache[mod]) !== undefined)) {
-    (function traverse(mod) {
-      mod.children.forEach(function (child) {
-        traverse(child);
-      });
-      callback(mod);
-    }(mod));
-  }
-}

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -42,14 +42,14 @@ module.exports = {
     for (let funcConf of funcConfs) {
       for (let httpEvent of funcConf.events) {
         const method = httpEvent.method.toLowerCase();
-        const endpoint = `/${httpEvent.path}`;
+        const endpoint = `/${this.options.stage}/${httpEvent.path}`;
         const path = endpoint.replace(/\{(.+?)\}/g, ':$1');
         let handler = this._handerBase(funcConf.id);
         if (httpEvent.cors) {
           handler = this._handlerAddCors(handler);
         }
         app[method](
-          path, // TODO add env prefix
+          path,
           handler
         );
         console.log(`  ${method.toUpperCase()} - http://localhost:${this._getPort()}${endpoint}`);

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -1,0 +1,116 @@
+'use strict';
+
+const BbPromise = require('bluebird');
+const webpack = require('webpack');
+const express = require('express');
+const bodyParser = require('body-parser');
+
+module.exports = {
+  serve() {
+    this.serverless.cli.log('Serving functions...');
+
+    const compiler = webpack(this.webpackConfig);
+    const app = this._newExpressApp();
+    const port = this._getPort();
+
+    app.listen(port, () => {
+      compiler.watch({}, (err, stats) => {
+        if (err) {
+          throw err;
+        }
+        this.handler = this.loadHandler(stats);
+      });
+    });
+
+    return BbPromise.resolve();
+  },
+
+  _newExpressApp() {
+    const app = express();
+    const funcConfs = this._getFuncConfigs();
+
+    app.use(bodyParser.json({ limit: '5mb' }));
+
+    app.use((req, res, next) => {
+      if(req.method !== 'OPTIONS') {
+        next();
+      } else {
+        res.status(200).end();
+      }
+    });
+
+    for (let funcConf of funcConfs) {
+      for (let httpEvent of funcConf.events) {
+        const method = httpEvent.method.toLowerCase();
+        const endpoint = `/${httpEvent.path}`;
+        const path = endpoint.replace(/\{(.+?)\}/g, ':$1');
+        let handler = this._handerBase(funcConf.id);
+        if (httpEvent.cors) {
+          handler = this._handlerAddCors(handler);
+        }
+        app[method](
+          path, // TODO add env prefix
+          handler
+        );
+        console.log(`  ${method.toUpperCase()} - http://localhost:${this._getPort()}${endpoint}`);
+      }
+    }
+
+    return app;
+  },
+
+  _getFuncConfigs() {
+    const funcConfs = [];
+    const inputfuncConfs = this.serverless.service.functions;
+    for (let funcName in inputfuncConfs) {
+      const funcConf = inputfuncConfs[funcName];
+      const httpEvents = funcConf.events
+        .filter(e => e.hasOwnProperty('http'))
+        .map(e => e.http);
+      if (httpEvents.length > 0) {
+        funcConfs.push(Object.assign({}, funcConf, {
+          id: funcName,
+          events: httpEvents,
+        }));
+      }
+    }
+    return funcConfs;
+  },
+
+  _getPort() {
+    return this.options.port || 8000;
+  },
+
+  _handlerAddCors(handler) {
+    return (req, res, next) => {
+      res.header('Access-Control-Allow-Origin', '*');
+      res.header( 'Access-Control-Allow-Methods', 'GET,PUT,HEAD,PATCH,POST,DELETE,OPTIONS');
+      res.header( 'Access-Control-Allow-Headers', 'Authorization,Content-Type,x-amz-date,x-amz-security-token');
+      handler(req, res, next);
+    };
+  },
+
+  _handerBase(funcId) {
+    return (req, res, next) => {
+      const func = this.handler[funcId];
+      const event = {
+        method: req.method,
+        headers: req.headers,
+        body: req.body,
+        path: req.params,
+        query: req.query,
+        // principalId,
+        // stageVariables,
+      };
+      const context = this.getContext(funcId);
+      func(event, context, (err, resp) => {
+        if (err) {
+          console.error(err);
+          res.sendStatus(500);
+        } else {
+          res.status(200).send(resp);
+        }
+      });
+    }
+  },
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,37 @@
+function guid() {
+  function s4() {
+    return Math.floor((1 + Math.random()) * 0x10000)
+      .toString(16)
+      .substring(1);
+  }
+  return s4() + s4() + '-' + s4() + '-' + s4() + '-' + s4() + '-' + s4() + s4() + s4();
+}
+
+function purgeCache(moduleName) {
+  searchCache(moduleName, function (mod) {
+    delete require.cache[mod.id];
+  });
+  Object.keys(module.constructor._pathCache).forEach(function(cacheKey) {
+    if (cacheKey.indexOf(moduleName)>0) {
+     delete module.constructor._pathCache[cacheKey];
+    }
+  });
+}
+
+function searchCache(moduleName, callback) {
+  var mod = require.resolve(moduleName);
+  if (mod && ((mod = require.cache[mod]) !== undefined)) {
+    (function traverse(mod) {
+      mod.children.forEach(function (child) {
+        traverse(child);
+      });
+      callback(mod);
+    }(mod));
+  }
+}
+
+module.exports = {
+  guid,
+  purgeCache,
+  searchCache,
+};

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
   "homepage": "https://github.com/elastic-coders/serverless-webpack#readme",
   "dependencies": {
     "bluebird": "^3.4.0",
+    "body-parser": "^1.15.2",
+    "express": "^4.14.0",
     "fs-extra": "^0.26.7",
     "webpack": "^1.13.1"
   }


### PR DESCRIPTION
This adds the command `serverless webpack serve` to simulate the API Gateway locally.

- [x] have `serverless webpack serve` command workng
- [x] send region/stage variables
- [x] add readme documentation