### PR TITLE
Lifecycle event name changed

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ class ServerlessWebpack {
     };
 
     this.hooks = {
-      'before:deploy:createDeploymentPackage': () => BbPromise.bind(this)
+      'before:deploy:createDeploymentArtifacts': () => BbPromise.bind(this)
         .then(this.validate)
         .then(this.compile),
 


### PR DESCRIPTION
Several lifecycle event names for deploy plugin [have been renamed](https://github.com/serverless/serverless/issues/1577#issuecomment-238226700) in the latest version of Serverless. Here's the fix.