### PR TITLE
Multiple webpack entrypoint support

### DIFF
--- a/examples/multiple-entries/event.json
+++ b/examples/multiple-entries/event.json
@@ -1,0 +1,5 @@
+{
+  "key3": "value3",
+  "key2": "value2",
+  "key1": "value1"
+}

--- a/examples/multiple-entries/first.js
+++ b/examples/multiple-entries/first.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports.hello = function (event, context, cb) {
+ cb(null, { message: 'First module', event });
+}

--- a/examples/multiple-entries/package.json
+++ b/examples/multiple-entries/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "serverless-webpack-multiple-entries-example",
+  "version": "1.0.0",
+  "description": "Serverless webpack example",
+  "main": "first.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Nicola Peduzzi <thenikso@gmail.com> (http://nikso.net)",
+  "license": "MIT",
+  "devDependencies": {
+    "serverless-webpack": "^1.0.0-beta.2",
+    "webpack": "^1.13.1"
+  }
+}

--- a/examples/multiple-entries/second.js
+++ b/examples/multiple-entries/second.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports.hello = function (event, context, cb) {
+ cb(null, { message: 'Second module', event });
+}

--- a/examples/multiple-entries/serverless.env.yml
+++ b/examples/multiple-entries/serverless.env.yml
@@ -1,0 +1,15 @@
+# This is the Serverless Environment File
+#
+# It contains listing of your stages and their regions
+# It also manages serverless variables at 3 levels:
+#    - common variables: variables that apply to all stages/regions
+#    - stage variables: variables that apply to a specific stage
+#    - region variables: variables that apply to a specific region
+
+vars:
+stages:
+  dev:
+    vars:
+    regions:
+      us-east-1:
+        vars:

--- a/examples/multiple-entries/serverless.yml
+++ b/examples/multiple-entries/serverless.yml
@@ -1,0 +1,23 @@
+service: serverless-webpack-multiple-entries-example
+
+# Add the serverless-webpack plugin
+plugins:
+  - serverless-webpack
+
+provider:
+  name: aws
+  runtime: nodejs4.3
+
+functions:
+  first:
+    handler: first.hello
+    events:
+      - http:
+          method: GET
+          path: first
+  second:
+    handler: second.hello
+    events:
+      - http:
+          method: GET
+          path: second

--- a/examples/multiple-entries/webpack.config.js
+++ b/examples/multiple-entries/webpack.config.js
@@ -1,0 +1,13 @@
+var path = require('path');
+
+module.exports = {
+  entry: {
+    first: './first.js',
+    second: './second.js'
+  },
+  output: {
+    libraryTarget: 'commonjs',
+    path: path.join(__dirname, '.webpack'),
+    filename: '[name].js'
+  },
+};

--- a/lib/run.js
+++ b/lib/run.js
@@ -6,13 +6,23 @@ const webpack = require('webpack');
 const utils = require('./utils');
 
 module.exports = {
-  loadHandler(stats) {
+  loadHandler(stats, functionId, purge) {
+    const handler = this.serverless.service.functions[functionId].handler.split('.');
+    const moduleFileName = `${handler[0]}.js`;
     const handlerFilePath = path.join(
       path.resolve(stats.compilation.options.output.path),
-      stats.compilation.options.output.filename
+      moduleFileName
     );
-    utils.purgeCache(handlerFilePath);
-    return require(handlerFilePath);
+    if (purge) {
+      utils.purgeCache(handlerFilePath);
+    }
+    const module = require(handlerFilePath);
+    const functionObjectPath = handler.slice(1);
+    let func = module;
+    for (let p of functionObjectPath) {
+      func = func[p];
+    }
+    return func;
   },
 
   getEvent() {
@@ -39,7 +49,7 @@ module.exports = {
 
     this.serverless.cli.log(`Run function ${functionName}...`);
 
-    const handler = this.loadHandler(stats)[functionName];
+    const handler = this.loadHandler(stats, functionName);
     const event = this.getEvent();
     const context = this.getContext(functionName);
 
@@ -67,7 +77,7 @@ module.exports = {
         throw err;
       }
       this.serverless.cli.log(`Run function ${functionName}...`);
-      const handler = this.loadHandler(stats)[functionName];
+      const handler = this.loadHandler(stats, functionName, true);
       const event = this.getEvent();
       const context = this.getContext(functionName);
       handler(

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -10,7 +10,8 @@ module.exports = {
     this.serverless.cli.log('Serving functions...');
 
     const compiler = webpack(this.webpackConfig);
-    const app = this._newExpressApp();
+    const funcConfs = this._getFuncConfigs();
+    const app = this._newExpressApp(funcConfs);
     const port = this._getPort();
 
     app.listen(port, () => {
@@ -18,16 +19,23 @@ module.exports = {
         if (err) {
           throw err;
         }
-        this.handler = this.loadHandler(stats);
+        const loadedModules = [];
+        for (let funcConf of funcConfs) {
+          funcConf.handlerFunc = this.loadHandler(
+            stats,
+            funcConf.id,
+            loadedModules.indexOf(funcConf.moduleName) < 0
+          );
+          loadedModules.push(funcConf.moduleName);
+        }
       });
     });
 
     return BbPromise.resolve();
   },
 
-  _newExpressApp() {
+  _newExpressApp(funcConfs) {
     const app = express();
-    const funcConfs = this._getFuncConfigs();
 
     app.use(bodyParser.json({ limit: '5mb' }));
 
@@ -44,7 +52,7 @@ module.exports = {
         const method = httpEvent.method.toLowerCase();
         const endpoint = `/${this.options.stage}/${httpEvent.path}`;
         const path = endpoint.replace(/\{(.+?)\}/g, ':$1');
-        let handler = this._handerBase(funcConf.id);
+        let handler = this._handerBase(funcConf);
         if (httpEvent.cors) {
           handler = this._handlerAddCors(handler);
         }
@@ -71,6 +79,8 @@ module.exports = {
         funcConfs.push(Object.assign({}, funcConf, {
           id: funcName,
           events: httpEvents,
+          moduleName: funcConf.handler.split('.')[0],
+          handlerFunc: null,
         }));
       }
     }
@@ -90,9 +100,9 @@ module.exports = {
     };
   },
 
-  _handerBase(funcId) {
+  _handerBase(funcConf) {
     return (req, res, next) => {
-      const func = this.handler[funcId];
+      const func = funcConf.handlerFunc;
       const event = {
         method: req.method,
         headers: req.headers,
@@ -102,7 +112,7 @@ module.exports = {
         // principalId,
         // stageVariables,
       };
-      const context = this.getContext(funcId);
+      const context = this.getContext(funcConf.id);
       func(event, context, (err, resp) => {
         if (err) {
           console.error(err);


### PR DESCRIPTION
Starting from #4 this PR adds support for multiple entrypoints as well as fixing a problem with handler loading. 

Before this pr it was assumed that the function id was the same as the handler so:

```
functions:
  hello:
    handler: handler.hello
```

Worked, while:

```
functions:
  hello:
    handler: handler.something
```

would not. This should now be fixed.

TODO:

- [x] support multiple endpoints
- [ ] add tests