### PR TITLE
allow custom output filename

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -8,7 +8,7 @@ const utils = require('./utils');
 module.exports = {
   loadHandler(stats, functionId, purge) {
     const handler = this.serverless.service.functions[functionId].handler.split('.');
-    const moduleFileName = `${handler[0]}.js`;
+    const moduleFileName = stats.compilation.options.output.filename || `${handler[0]}.js`;
     const handlerFilePath = path.join(
       path.resolve(stats.compilation.options.output.path),
       moduleFileName


### PR DESCRIPTION
Currently webpack configs that specify a custom output filename will break this plugin. This fixes that.