### PR TITLE
Properly send CORS headers for options request

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -39,23 +39,18 @@ module.exports = {
 
     app.use(bodyParser.json({ limit: '5mb' }));
 
-    app.use(function optionsHandler(req, res, next) {
-      if(req.method !== 'OPTIONS') {
-        next();
-      } else {
-        res.sendStatus(200);
-      }
-    });
-
     for (let funcConf of funcConfs) {
       for (let httpEvent of funcConf.events) {
         const method = httpEvent.method.toLowerCase();
         const endpoint = `/${this.options.stage}/${httpEvent.path}`;
         const path = endpoint.replace(/\{(.+?)\}/g, ':$1');
         let handler = this._handlerBase(funcConf);
+        let optionsHandler = this._optionsHandler;
         if (httpEvent.cors) {
           handler = this._handlerAddCors(handler);
+          optionsHandler = this._handlerAddCors(optionsHandler);
         }
+        app.options(path, optionsHandler);
         app[method](
           path,
           handler
@@ -121,5 +116,9 @@ module.exports = {
         }
       });
     }
+  },
+
+  _optionsHandler(req, res) {
+    res.sendStatus(200);
   },
 };

--- a/tests/express.mock.js
+++ b/tests/express.mock.js
@@ -5,6 +5,7 @@ const appMock = {
   use: sinon.spy(),
   get: sinon.spy(),
   post: sinon.spy(),
+  options: sinon.spy(),
 };
 
 const expressMock = sinon.stub().returns(appMock);
@@ -15,6 +16,7 @@ expressMock._resetSpies = () => {
   appMock.use.reset();
   appMock.get.reset();
   appMock.post.reset();
+  appMock.options.reset();
 };
 
 module.exports = () => expressMock;


### PR DESCRIPTION
The old options handler did not send CORS headers and this caused requests to fail when using browser `fetch`. This adds a separate options handler for each function and adds CORS headers if needed.