### PR TITLE
fixed issue causing cleanup function to fail due to .serverless folde…

### DIFF
--- a/lib/cleanup.js
+++ b/lib/cleanup.js
@@ -7,22 +7,21 @@ const fse = require('fs-extra');
 module.exports = {
   cleanup() {
     const webpackOutputPath = this.webpackOutputPath;
+    const artifact = path.basename(this.serverless.service.package.artifact);
 
+    const source = path.join(webpackOutputPath, '.serverless', artifact);
+    const destination = path.join(this.serverless.config.servicePath, '.serverless', artifact);
     const moveArtifact = new BbPromise((resolve, reject) => {
       if (this.originalServicePath) {
         this.serverless.config.servicePath = this.originalServicePath;
         fse.move(
-          path.join(webpackOutputPath, '.serverless'),
-          path.join(this.serverless.config.servicePath, '.serverless'),
+            source,
+            destination,
           (err) => {
             if (err) {
               reject(err);
             } else {
-              this.serverless.service.package.artifact = path.join(
-                this.serverless.config.servicePath,
-                '.serverless',
-                path.basename(this.serverless.service.package.artifact)
-              );
+              this.serverless.service.package.artifact = destination;
               resolve();
             }
           }


### PR DESCRIPTION
…r already exists

from now, move will only move the output of the build instead of the entire folder which is safer