### PR TITLE
Accept string format http events

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -44,6 +44,15 @@ module.exports = {
 
     for (let funcConf of funcConfs) {
       for (let httpEvent of funcConf.events) {
+        if (typeof httpEvent === 'string') {
+          let split = httpEvent.split(' ');
+          if (split.length >= 2) {
+            httpEvent = {
+              method: split[0],
+              path: split[1]
+            }
+          }
+        }
         const method = httpEvent.method.toLowerCase();
         let endpoint = `/${httpEvent.path}`;
         if (this.options.stage) {


### PR DESCRIPTION
Shims in an httpEvent object of the correct shape if the original httpEvent is a string.
