### PR TITLE
Added hooks to transpile with serverless-webpack before starting serverless-offline.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 dist
 .webpack
 coverage
+
+.idea

--- a/index.js
+++ b/index.js
@@ -117,6 +117,14 @@ class ServerlessWebpack {
       'webpack:serve:serve': () => BbPromise.bind(this)
         .then(this.validate)
         .then(this.serve),
+
+      'before:offline:start:init': () => BbPromise.bind(this)
+        .then(this.validate)
+        .then(this.compile),
+
+      'before:offline:start': () => BbPromise.bind(this)
+        .then(this.validate)
+        .then(this.compile),
     };
   }
 }

--- a/lib/cleanup.js
+++ b/lib/cleanup.js
@@ -18,6 +18,19 @@ module.exports = {
             if (err) {
               reject(err);
             } else {
+              if (this.serverless.service.package.individually) {
+                const functionNames = this.serverless.service.getAllFunctions();
+                functionNames.forEach(name => {
+                  this.serverless.service.functions[name].artifact = path.join(
+                      this.serverless.config.servicePath,
+                      '.serverless',
+                      path.basename(this.serverless.service.functions[name].artifact)
+                  );
+                });
+                resolve();
+                return;
+              }
+
               this.serverless.service.package.artifact = path.join(
                 this.serverless.config.servicePath,
                 '.serverless',


### PR DESCRIPTION
This will allow us to combine serverless-webpack and serverless-offline to get the best of both plugins. 

This will resolve #29 when the hooks are include in the serverless-offline plugin in a seperate pull request [#19](https://github.com/dherault/serverless-offline/pull/119).