### PR TITLE
fix for deploying individual packages.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 dist
 .webpack
 coverage
+
+.idea

--- a/lib/cleanup.js
+++ b/lib/cleanup.js
@@ -18,6 +18,19 @@ module.exports = {
             if (err) {
               reject(err);
             } else {
+              if (this.serverless.service.package.individually) {
+                const functionNames = this.serverless.service.getAllFunctions();
+                functionNames.forEach(name => {
+                  this.serverless.service.functions[name].artifact = path.join(
+                      this.serverless.config.servicePath,
+                      '.serverless',
+                      path.basename(this.serverless.service.functions[name].artifact)
+                  );
+                });
+                resolve();
+                return;
+              }
+
               this.serverless.service.package.artifact = path.join(
                 this.serverless.config.servicePath,
                 '.serverless',


### PR DESCRIPTION
Serverless added the ability to deploy functions [individually](https://github.com/serverless/serverless/blob/9ebf296762e502d42eba10108cea4bda94fa0c09/docs/01-guide/10-packaging.md#packaging-functions-separately) when using `serverless-webpack` it doesn't change the paths of the individual artifacts similar to how it change the this.serverless.package.artifact.

This solutions is very brittle as it copies how individual packages was implemented.
