### PR TITLE
Add compatibility with serverless-offline plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,3 +190,20 @@ plugin with Babel. To try it, from inside the example folder:
 
 - `npm install` to install dependencies
 - `serverless webpack run -f hello` to run the example function
+
+
+## Compatibility with other plugins
+
+### [`serverless-offline`](https://github.com/dherault/serverless-offline) 
+
+Add both plugins to your `serverless.yml` file:
+
+```yaml
+plugins:
+  - serverless-webpack
+  - serverless-offline
+```
+
+Make sure that `serverless-webpack` is above `serverless-offline` so it will be loaded earlier.
+
+Now your functions will be automatically built before running `serverless offline`.

--- a/index.js
+++ b/index.js
@@ -117,6 +117,10 @@ class ServerlessWebpack {
       'webpack:serve:serve': () => BbPromise.bind(this)
         .then(this.validate)
         .then(this.serve),
+
+      'before:offline:start': () => BbPromise.bind(this)
+        .then(this.validate)
+        .then(this.compile),
     };
   }
 }


### PR DESCRIPTION
This PR adds basic compatibility with [`serverless-offline`](https://github.com/dherault/serverless-offline) plugin.
It hooks the `serverless-offline` event, validates and compiles functions before running the plugin.
I also added a note to the README about it.

Closes #29