### PR TITLE
Catering to Lambda proxy enabled API request/response

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -50,7 +50,7 @@ module.exports = {
           endpoint = `/${this.options.stage}${endpoint}`;
         }
         const path = endpoint.replace(/\{(.+?)\}/g, ':$1');
-        let handler = this._handlerBase(funcConf);
+        let handler = this._handlerBase(funcConf, httpEvent);
         let optionsHandler = this._optionsHandler;
         if (httpEvent.cors) {
           handler = this._handlerAddCors(handler);
@@ -101,7 +101,9 @@ module.exports = {
     };
   },
 
-  _handlerBase(funcConf) {
+  _handlerBase(funcConf, httpEvent) {
+    const isLambdaProxyIntegration = httpEvent && httpEvent.integration !== 'lambda'
+
     return (req, res) => {
       const func = funcConf.handlerFunc;
       const event = {
@@ -109,14 +111,18 @@ module.exports = {
         headers: req.headers,
         body: req.body,
         path: req.params,
-        queryStringParameters: req.query,
+        [isLambdaProxyIntegration ? 'queryStringParameters' : 'query']: req.query
         // principalId,
         // stageVariables,
       };
       const context = this.getContext(funcConf.id);
       func(event, context, (err, resp) => {
         if (err) {
-          res.status(500).send(err);
+          return res.status(500).send(err);
+        }
+
+        if (isLambdaProxyIntegration) {
+          res.status(resp.statusCode).send(resp.body);
         } else {
           res.status(200).send(resp);
         }

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -109,7 +109,7 @@ module.exports = {
         headers: req.headers,
         body: req.body,
         path: req.params,
-        query: req.query,
+        queryStringParameters: req.query,
         // principalId,
         // stageVariables,
       };

--- a/tests/serve.test.js
+++ b/tests/serve.test.js
@@ -86,7 +86,7 @@ describe('serve', () => {
           headers: 'testheaders',
           method: 'testmethod',
           path: 'testparams',
-          query: 'testquery',
+          queryStringParameters: 'testquery',
         },
         'testContext'
       );

--- a/tests/serve.test.js
+++ b/tests/serve.test.js
@@ -64,6 +64,9 @@ describe('serve', () => {
         id: 'testFuncId',
         handlerFunc: testHandlerFunc,
       };
+      const testHttpEvent = {
+        integration: 'lambda'
+      }
       const testReq = {
         method: 'testmethod',
         headers: 'testheaders',
@@ -76,7 +79,7 @@ describe('serve', () => {
       };
       testRes.status = sinon.stub().returns(testRes);
       module.getContext = sinon.stub().returns('testContext');
-      const handler = module._handlerBase(testFuncConf);
+      const handler = module._handlerBase(testFuncConf, testHttpEvent);
       handler(testReq, testRes);
       expect(testRes.status).to.have.been.calledWith(200);
       expect(testRes.send).to.have.been.calledWith(testHandlerResp);
@@ -86,7 +89,7 @@ describe('serve', () => {
           headers: 'testheaders',
           method: 'testmethod',
           path: 'testparams',
-          queryStringParameters: 'testquery',
+          query: 'testquery',
         },
         'testContext'
       );
@@ -110,6 +113,44 @@ describe('serve', () => {
       handler({}, testRes);
       expect(testRes.status).to.have.been.calledWith(500);
       expect(testRes.send).to.have.been.calledWith(testHandlerErr);
+    });
+
+    it('handles lambda-proxy integration for request and response', () => {
+      const testHandlerResp = { statusCode: 200, body: 'testHandlerResp' };
+      const testHandlerFunc = sinon.spy((ev, ct, cb) => {
+        cb(null, testHandlerResp);
+      });
+      const testFuncConf = {
+        id: 'testFuncId',
+        handlerFunc: testHandlerFunc,
+      };
+      const testHttpEvent = {}
+      const testReq = {
+        method: 'testmethod',
+        headers: 'testheaders',
+        body: 'testbody',
+        params: 'testparams',
+        query: 'testquery',
+      };
+      const testRes = {
+        send: sinon.spy(),
+      };
+      testRes.status = sinon.stub().returns(testRes);
+      module.getContext = sinon.stub().returns('testContext');
+      const handler = module._handlerBase(testFuncConf, testHttpEvent);
+      handler(testReq, testRes);
+      expect(testRes.status).to.have.been.calledWith(testHandlerResp.statusCode);
+      expect(testRes.send).to.have.been.calledWith(testHandlerResp.body);
+      expect(testHandlerFunc).to.have.been.calledWith(
+        {
+          body: 'testbody',
+          headers: 'testheaders',
+          method: 'testmethod',
+          path: 'testparams',
+          queryStringParameters: 'testquery',
+        },
+        'testContext'
+      );
     });
   });
 


### PR DESCRIPTION
If lambda-proxy is enabled in API gateway, the API server has some minor differences in the way it processes the request query and responding back.

b3c9549 - This commit changes the event.query to event.queryStringParameters as what API gateway passes in as.

1e4c947 - This commit changes the response to expect an object with statusCode and body and sends back the response properly. This is what is expected in lambda-proxy.
Ideally, we should check if the function is lambda-proxy enabled or not and then render the response accordingly. However, I cannot locate the config/settings in the code. If you can guide me on this, I can send another PR for it.