### PR TITLE
Yet another implementation for compatibility with serverless-offline

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const BbPromise = require('bluebird');
 
 const validate = require('./lib/validate');
 const compile = require('./lib/compile');
+const wpwatch = require('./lib/wpwatch');
 const cleanup = require('./lib/cleanup');
 const run = require('./lib/run');
 const serve = require('./lib/serve');
@@ -18,6 +19,7 @@ class ServerlessWebpack {
       this,
       validate,
       compile,
+      wpwatch,
       cleanup,
       run,
       serve,
@@ -117,6 +119,10 @@ class ServerlessWebpack {
       'webpack:serve:serve': () => BbPromise.bind(this)
         .then(this.validate)
         .then(this.serve),
+
+      'before:offline:start': () => BbPromise.bind(this)
+        .then(this.validate)
+        .then(this.wpwatch),
     };
   }
 }

--- a/lib/wpwatch.js
+++ b/lib/wpwatch.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const BbPromise = require('bluebird');
+const webpack = require('webpack');
+
+module.exports = {
+  wpwatch() {
+    this.serverless.cli.log('Watching with Webpack...');
+
+    const compiler = webpack(this.webpackConfig);
+    compiler.watch({}, (err, stats) => {
+        if (err) {
+          throw err;
+        }
+
+        if (stats) {
+            console.log("Webpack rebuilt");
+        }
+      });
+
+    return BbPromise.resolve();
+  },
+};


### PR DESCRIPTION
Replaces #55, #49, #47 

This runs webpack.watch rather than webpack.compile for developer sanity reasons.