### PR TITLE
Support environment variables on 'run'

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -44,6 +44,13 @@ module.exports = {
     };
   },
 
+  setEnvironmentVars(functionName) {
+    const providerEnvVars = this.serverless.service.provider.environment || {};
+    const functionEnvVars = this.serverless.service.functions[functionName].environment || {};
+
+    Object.assign(process.env, providerEnvVars, functionEnvVars);
+  },
+
   run(stats) {
     const functionName = this.options.function;
 
@@ -52,6 +59,7 @@ module.exports = {
     const handler = this.loadHandler(stats, functionName);
     const event = this.getEvent();
     const context = this.getContext(functionName);
+    this.setEnvironmentVars(functionName);
 
     return new BbPromise((resolve, reject) => handler(
       event,
@@ -80,6 +88,8 @@ module.exports = {
       const handler = this.loadHandler(stats, functionName, true);
       const event = this.getEvent();
       const context = this.getContext(functionName);
+      this.setEnvironmentVars(functionName);
+
       handler(
         event,
         context,

--- a/lib/run.js
+++ b/lib/run.js
@@ -16,6 +16,8 @@ module.exports = {
     if (purge) {
       utils.purgeCache(handlerFilePath);
     }
+    //set environment before requiring, as imported modules will be immediately
+    this.setEnvironmentVars(functionId);
     const module = require(handlerFilePath);
     const functionObjectPath = handler.slice(1);
     let func = module;
@@ -49,6 +51,7 @@ module.exports = {
     const functionEnvVars = this.serverless.service.functions[functionName].environment || {};
 
     Object.assign(process.env, providerEnvVars, functionEnvVars);
+    console.log('core', process.env.NODE_ENV);
   },
 
   run(stats) {
@@ -59,7 +62,6 @@ module.exports = {
     const handler = this.loadHandler(stats, functionName);
     const event = this.getEvent();
     const context = this.getContext(functionName);
-    this.setEnvironmentVars(functionName);
 
     return new BbPromise((resolve, reject) => handler(
       event,
@@ -88,7 +90,6 @@ module.exports = {
       const handler = this.loadHandler(stats, functionName, true);
       const event = this.getEvent();
       const context = this.getContext(functionName);
-      this.setEnvironmentVars(functionName);
 
       handler(
         event,


### PR DESCRIPTION
serverless supports setting environment variables at the global or function level. 

This adds support for those environment variables locally when running `serverless webpack invoke` just like when running `serverless invoke local`