### PR TITLE
Fix naming problem for lambda-proxy

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -110,7 +110,7 @@ module.exports = {
         method: req.method,
         headers: req.headers,
         body: req.body,
-        path: req.params,
+        [isLambdaProxyIntegration ? 'pathParameters' : 'path']: req.params,
         [isLambdaProxyIntegration ? 'queryStringParameters' : 'query']: req.query
         // principalId,
         // stageVariables,

--- a/tests/serve.test.js
+++ b/tests/serve.test.js
@@ -146,7 +146,7 @@ describe('serve', () => {
           body: 'testbody',
           headers: 'testheaders',
           method: 'testmethod',
-          path: 'testparams',
+          pathParameters: 'testparams',
           queryStringParameters: 'testquery',
         },
         'testContext'


### PR DESCRIPTION
As I mentioned in #57, path parameter for lambda-proxy is passed as event.pathParameters
instead of event.path. This commit fixes the problem.