### PR TITLE
Corrected babel example - handler.js

### DIFF
--- a/examples/babel/handler.js
+++ b/examples/babel/handler.js
@@ -8,8 +8,11 @@ export const hello = (event, context, cb) => {
   });
   p
     .then(r => cb(null, {
-      message: 'Go Serverless Webpack (Babel) v1.0! Your function executed successfully!',
-      event,
+      statusCode: 200,
+      body: JSON.stringify({
+        "message": 'Go Serverless Webpack (Babel) v1.0! Your function executed successfully!',
+        "event": event
+      }),
     }))
     .catch(e => cb(e));
 };


### PR DESCRIPTION
Now it complies with Lambda output format as defined [here](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-set-up-simple-proxy.html#api-gateway-simple-proxy-for-lambda-output-format).

Before i got the following error in API-Gateway:

> Sat Jan 07 00:11:42 UTC 2017 : Execution failed due to configuration error: Malformed Lambda proxy response
Sat Jan 07 00:11:42 UTC 2017 : Method completed with status: 502

And as response to the request i only got:

```
{
  "message": "Internal server error"
}
```
