### PR TITLE
Support the `any` http method with the .all express handler

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -57,7 +57,7 @@ module.exports = {
           optionsHandler = this._handlerAddCors(optionsHandler);
         }
         app.options(path, optionsHandler);
-        app[method](
+        app[method === 'any' ? 'all' : method](
           path,
           handler
         );


### PR DESCRIPTION
API Gateway now allows you to specify proxy routes like so:

```yaml
functions:
  hello:
    handler: handler.hello
    events:
      - http:
          path: ''
          method: any
      - http:
          path: '/{proxy+}'
          method: any

```

Sources:
- https://aws.amazon.com/blogs/aws/api-gateway-update-new-features-simplify-api-development/
- https://aws.amazon.com/blogs/compute/easier-integration-with-aws-lambda-and-amazon-api-gateway/