### PR TITLE
Make stage path prefixing optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ serverless webpack serve
 Options are:
 
 - `--port` or `-p` (optional) The local server port. Defaults to `8000`
+- `--pathPrefix` or `-x` (optional) Add stage as a prefix to all path routes.
+Defaults to value of `provider.stage` defined in `serverless.yml`, which defaults to `dev`
 
 The `serve` command will automatically look for the local `serverless.yml` and serve
 all the `http` events. For example this configuration will generate a GET enpoint:

--- a/index.js
+++ b/index.js
@@ -84,6 +84,10 @@ class ServerlessWebpack {
                 usage: 'The local server port',
                 shortcut: 'p',
               },
+              stagePrefix: {
+                usage: 'Add stage as a prefix to all path routes',
+                shortcut: 'x',
+              },
             },
           },
         },

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -46,8 +46,9 @@ module.exports = {
       for (let httpEvent of funcConf.events) {
         const method = httpEvent.method.toLowerCase();
         let endpoint = `/${httpEvent.path}`;
-        if (this.options.stage) {
-          endpoint = `/${this.options.stage}${endpoint}`;
+        if (this.options.stagePrefix) {
+          const stage = this.options.stage ? this.options.stage : this.serverless.service.provider.stage
+          endpoint = `/${stage}${endpoint}`;
         }
         const path = endpoint.replace(/\{(.+?)\}/g, ':$1');
         let handler = this._handlerBase(funcConf, httpEvent);


### PR DESCRIPTION
By default you don't need path prefixing when you specify a stage