### PR TITLE
Simulate Lambda Proxy Integration

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -5,6 +5,11 @@ const webpack = require('webpack');
 const express = require('express');
 const bodyParser = require('body-parser');
 
+const supportedMethods = 'get post'.split(' ');
+const resolveMethods = (method) => (method.toLowerCase() === 'any'
+  ? supportedMethods
+  : [method.toLowerCase()]);
+
 module.exports = {
   serve() {
     this.serverless.cli.log('Serving functions...');
@@ -44,12 +49,13 @@ module.exports = {
 
     for (let funcConf of funcConfs) {
       for (let httpEvent of funcConf.events) {
-        const method = httpEvent.method.toLowerCase();
-        let endpoint = `/${httpEvent.path}`;
+        let endpoint = `/${httpEvent.path}`.replace(/^\/+/, '/');
         if (this.options.stage) {
           endpoint = `/${this.options.stage}${endpoint}`;
         }
-        const path = endpoint.replace(/\{(.+?)\}/g, ':$1');
+        const path = endpoint
+          .replace(/\{proxy\+\}/, '*')
+          .replace(/\{(.+?)\}/g, ':$1');
         let handler = this._handlerBase(funcConf, httpEvent);
         let optionsHandler = this._optionsHandler;
         if (httpEvent.cors) {
@@ -57,11 +63,10 @@ module.exports = {
           optionsHandler = this._handlerAddCors(optionsHandler);
         }
         app.options(path, optionsHandler);
-        app[method](
-          path,
-          handler
-        );
-        this.serverless.cli.consoleLog(`  ${method.toUpperCase()} - http://localhost:${this._getPort()}${endpoint}`);
+        for (let method of resolveMethods(httpEvent.method)) {
+          app[method](path, handler);
+        }
+        this.serverless.cli.consoleLog(`  ${httpEvent.method.toUpperCase()} - http://localhost:${this._getPort()}${endpoint}`);
       }
     }
 

--- a/tests/serve.test.js
+++ b/tests/serve.test.js
@@ -349,6 +349,51 @@ describe('serve', () => {
         testHandlerOptions
       );
     });
+
+    it('should simulate Lambda Proxy Integration', () => {
+      const testFuncsConfs = [
+        {
+          'events': [
+            {
+              'method': 'any',
+              'path': '/{proxy+}',
+              'cors': true,
+            }
+          ],
+          'handler': 'module1.func1handler',
+          'handlerFunc': null,
+          'id': 'func1',
+          'moduleName': 'module1',
+        },
+      ];
+      const testStage = 'test';
+      module.options.stage = testStage;
+      const testHandlerBase = 'testHandlerBase';
+      const testHandlerCors = 'testHandlerCors';
+      const testHandlerOptions = 'testHandlerOptions';
+      module._handlerBase = sinon.stub().returns(testHandlerBase);
+      module._optionsHandler = testHandlerOptions;
+      module._handlerAddCors = sinon.stub().returns(testHandlerCors);
+      const app = module._newExpressApp(testFuncsConfs);
+      expect(app.get).to.have.callCount(1);
+      expect(app.get).to.have.been.calledWith(
+        '/test/*',
+        testHandlerCors
+      );
+      expect(app.post).to.have.callCount(1);
+      expect(app.post).to.have.been.calledWith(
+        '/test/*',
+        testHandlerCors
+      );
+      expect(app.options).to.have.callCount(1);
+      expect(app.options).to.have.been.calledWith(
+        '/test/*',
+        testHandlerCors
+      );
+      expect(module.serverless.cli.consoleLog).to.have.been.calledWith(
+        '  ANY - http://localhost:8000/test/{proxy+}'
+      );
+    });
   });
 
   describe('serve method', () => {


### PR DESCRIPTION
http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-create-api-as-simple-proxy-for-lambda.html#api-gateway-create-api-as-simple-proxy-for-lambda-build