### PR TITLE
Set output headers when lambda proxy is used

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -122,6 +122,11 @@ module.exports = {
         }
 
         if (isLambdaProxyIntegration) {
+          if (resp.headers) {
+            for (let header in Object.keys(resp.headers)) {
+              res.header(header, resp.headers[header]);
+            }
+          }
           res.status(resp.statusCode || 200).send(resp.body);
         } else {
           res.status(200).send(resp);


### PR DESCRIPTION
API Gateway now recognizes `headers` as part of [Lambda Function output](http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-set-up-simple-proxy.html#api-gateway-simple-proxy-for-lambda-output-format).