### PR TITLE
Make webpack a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
     "body-parser": "^1.15.2",
     "express": "^4.14.0",
     "fs-extra": "^0.26.7",
-    "npm-programmatic": "0.0.5",
-    "webpack": "^1.13.1"
+    "npm-programmatic": "0.0.5"
   },
   "devDependencies": {
     "chai": "^3.5.0",
@@ -42,5 +41,8 @@
     "serverless": "^1.0.0-beta.2",
     "sinon": "^1.17.5",
     "sinon-chai": "^2.8.0"
+  },
+  "peerDependencies": {
+    "webpack": "*"
   }
 }


### PR DESCRIPTION
Users can now use webpack 2 instead of 1.

Closes #62