### PR TITLE
Pack all dependencies defined in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ custom:
   webpackIncludeModules: true # enable auto-packing of external modules
 ```
 
-All modules stated in `externals` will be excluded from bundled files. If an excluded module
-is stated as `dependencies` in `package.json`, it will be packed into the Serverless
+All modules stated in `externals` will be excluded from bundled files. Every module 
+stated as `dependencies` in `package.json` will be packed into the Serverless
 artifact under the `node_modules` directory.
 
 By default, the plugin will use the `package.json` file in working directory, If you want to

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const wpwatch = require('./lib/wpwatch');
 const cleanup = require('./lib/cleanup');
 const run = require('./lib/run');
 const serve = require('./lib/serve');
-const packExternalModules = require('./lib/packExternalModules');
+const packModules = require('./lib/packModules');
 
 class ServerlessWebpack {
   constructor(serverless, options) {
@@ -23,7 +23,7 @@ class ServerlessWebpack {
       cleanup,
       run,
       serve,
-      packExternalModules
+      packModules
     );
 
     this.commands = {
@@ -94,7 +94,7 @@ class ServerlessWebpack {
       'before:deploy:createDeploymentArtifacts': () => BbPromise.bind(this)
         .then(this.validate)
         .then(this.compile)
-        .then(this.packExternalModules),
+        .then(this.packModules),
 
       'after:deploy:createDeploymentArtifacts': () => BbPromise.bind(this)
         .then(this.cleanup),
@@ -104,7 +104,7 @@ class ServerlessWebpack {
 
       'webpack:compile': () => BbPromise.bind(this)
         .then(this.compile)
-        .then(this.packExternalModules),
+        .then(this.packModules),
 
       'webpack:invoke:invoke': () => BbPromise.bind(this)
         .then(this.validate)

--- a/lib/packModules.js
+++ b/lib/packModules.js
@@ -5,69 +5,30 @@ const fs = require('fs');
 const path = require('path');
 const npm = require('npm-programmatic');
 
-function getProdModules(externalModules, packagePath) {
+function getModules(packagePath) {
 
   const packageJson = require(path.join(process.cwd(), packagePath));
 
-  const prodModules = [];
+  const modules = [];
 
   // only process the module stated in dependencies section
   if (!packageJson.dependencies) {
     return []
   }
 
-  externalModules.forEach(module => {
-
+  Object.keys(packageJson.dependencies).forEach(module => {
     const moduleVersion = packageJson.dependencies[module];
 
     if (moduleVersion) {
-      prodModules.push(`${module}@${moduleVersion}`);
+      modules.push(`${module}@${moduleVersion}`);
     }
   });
 
-  return prodModules;
-}
-
-function getExternalModuleName(module) {
-
-  const path = /^external "(.*)"$/.exec(module.identifier())[1];
-
-
-  const pathComponents = path.split('/');
-
-  const main = pathComponents[0];
-
-  // this is a package within a namespace
-  if (main.charAt(0) == '@') {
-    return `${main}/${pathComponents[1]}`
-  }
-
-  return main
-}
-
-function isExternalModule(module) {
-  return module.identifier().indexOf('external ') === 0;
-}
-
-function getExternalModules(stats) {
-
-  const externals = new Set();
-
-  stats.compilation.chunks.forEach(function(chunk) {
-    // Explore each module within the chunk (built inputs):
-    chunk.modules.forEach(function(module) {
-      // Explore each source file path that was included into the module:
-      if (isExternalModule(module)) {
-        externals.add(getExternalModuleName(module));
-      }
-    });
-  });
-
-  return Array.from(externals);
+  return modules;
 }
 
 module.exports = {
-  packExternalModules(stats) {
+  packModules() {
 
     const includes = (
       this.serverless.service.custom &&
@@ -82,24 +43,22 @@ module.exports = {
 
       const packagePath = includes.packagePath || './package.json';
 
-      const externalModules = getExternalModules(stats);
-
       // this plugin will only install modules stated in dependencies section of package.json
-      const prodModules = getProdModules(externalModules, packagePath);
+      const modules = getModules(packagePath);
 
-      if (prodModules.length === 0) {
+      if (modules.length === 0) {
         return;
       }
 
-      this.serverless.cli.log('Packing external modules: ' + prodModules.join(", "));
+      this.serverless.cli.log('Packing modules: ' + modules.join(", "));
 
       const tmpPackageJson = path.join(this.serverless.config.servicePath, 'package.json');
-    
+
       // create a temp package.json in dist directory so that we can install the dependencies later.
       fs.writeFileSync(tmpPackageJson, "{}");
 
       return new BbPromise((resolve, reject) => {
-        npm.install(prodModules, {
+        npm.install(modules, {
           cwd: this.serverless.config.servicePath,
           save: true
         }).then(() => {


### PR DESCRIPTION
This will solve various issues with 'implicit' dependencies that aren't directly used in your code but required by other modules.
The developer himself is responsible to moderate the `dependencies` list and update it accordingly.