### PR TITLE
Add support for Catch-all path variables

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -49,7 +49,9 @@ module.exports = {
         if (this.options.stage) {
           endpoint = `/${this.options.stage}${endpoint}`;
         }
-        const path = endpoint.replace(/\{(.+?)\}/g, ':$1');
+        const path = endpoint
+          .replace(/\{(.+)\+\}/g, ':$1(*)')
+          .replace(/\{(.+?)\}/g, ':$1');
         let handler = this._handlerBase(funcConf, httpEvent);
         let optionsHandler = this._optionsHandler;
         if (httpEvent.cors) {

--- a/tests/serve.test.js
+++ b/tests/serve.test.js
@@ -349,6 +349,70 @@ describe('serve', () => {
         testHandlerOptions
       );
     });
+
+    it('should create express handlers for Catch-all path variables (i.e "{foo+}")', () => {
+      const testFuncsConfs = [
+        {
+          'events': [
+            {
+              'method': 'get',
+              'path': 'func1path/{foo+}',
+              'cors': true,
+            }
+          ],
+          'handler': 'module1.func1handler',
+          'handlerFunc': null,
+          'id': 'func1',
+          'moduleName': 'module1',
+        },
+        {
+          'events': [
+            {
+              'method': 'POST',
+              'path': 'func2path/{testParam+}',
+            }
+          ],
+          'handler': 'module2.func2handler',
+          'handlerFunc': null,
+          'id': 'func2',
+          'moduleName': 'module2',
+        },
+      ];
+      const testStage = 'test';
+      module.options.stage = testStage;
+      const testHandlerBase = 'testHandlerBase';
+      const testHandlerCors = 'testHandlerCors';
+      const testHandlerOptions = 'testHandlerOptions';
+      module._handlerBase = sinon.stub().returns(testHandlerBase);
+      module._optionsHandler = testHandlerOptions;
+      module._handlerAddCors = sinon.stub().returns(testHandlerCors);
+      const app = module._newExpressApp(testFuncsConfs);
+      expect(app.get).to.have.callCount(1);
+      expect(app.get).to.have.been.calledWith(
+        '/test/func1path/:foo(*)',
+        testHandlerCors
+      );
+      expect(module.serverless.cli.consoleLog).to.have.been.calledWith(
+        '  GET - http://localhost:8000/test/func1path/{foo+}'
+      );
+      expect(app.post).to.have.callCount(1);
+      expect(app.post).to.have.been.calledWith(
+        '/test/func2path/:testParam(*)',
+        testHandlerBase
+      );
+      expect(module.serverless.cli.consoleLog).to.have.been.calledWith(
+        '  POST - http://localhost:8000/test/func2path/{testParam+}'
+      );
+      expect(app.options).to.have.callCount(2);
+      expect(app.options.firstCall).to.have.been.calledWith(
+        '/test/func1path/:foo(*)',
+        testHandlerCors
+      );
+      expect(app.options.secondCall).to.have.been.calledWith(
+        '/test/func2path/:testParam(*)',
+        testHandlerOptions
+      );
+    });
   });
 
   describe('serve method', () => {


### PR DESCRIPTION
```yaml
functions:
  foo:
    handler: handler.foo
    events:
      - http:
          path: foo/{bar+}
          method: get
```
> **Catch-all Path Variables** – Instead of specifying individual paths and behaviors for groups of requests that fall within a common path (such as /store/), you can now specify a catch-all route that intercepts all requests to the path and routes them to the same function. For example a single greedy path (/store/{proxy+}) will intercept requests made to /store/list-products, /store/add-product, and /store/delete-product.

source: https://aws.amazon.com/blogs/aws/api-gateway-update-new-features-simplify-api-development/

PR #82 has some work around this but, from my test, it's implementation doesn't match what AWS has. e.g the name variable doesn't need to be called `{proxy+}`. And the named path variable must be available in `event.pathParameters`.
