### PR TITLE
Add support for ANY method

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -56,8 +56,10 @@ module.exports = {
           handler = this._handlerAddCors(handler);
           optionsHandler = this._handlerAddCors(optionsHandler);
         }
-        app.options(path, optionsHandler);
-        app[method](
+        if (method !== 'any') {
+          app.options(path, optionsHandler);
+        }
+        app[method === 'any' ? 'all' : method](
           path,
           handler
         );

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -51,13 +51,10 @@ module.exports = {
         }
         const path = endpoint.replace(/\{(.+?)\}/g, ':$1');
         let handler = this._handlerBase(funcConf, httpEvent);
-        let optionsHandler = this._optionsHandler;
         if (httpEvent.cors) {
           handler = this._handlerAddCors(handler);
-          optionsHandler = this._handlerAddCors(optionsHandler);
-        }
-        if (method !== 'any') {
-          app.options(path, optionsHandler);
+          let optionsHandler = this._handlerAddCors(this._optionsHandler);
+          if (method !== 'any') app.options(path, optionsHandler);
         }
         app[method === 'any' ? 'all' : method](
           path,

--- a/tests/express.mock.js
+++ b/tests/express.mock.js
@@ -6,6 +6,7 @@ const appMock = {
   get: sinon.spy(),
   post: sinon.spy(),
   options: sinon.spy(),
+  all: sinon.spy(),
 };
 
 const expressMock = sinon.stub().returns(appMock);
@@ -17,6 +18,7 @@ expressMock._resetSpies = () => {
   appMock.get.reset();
   appMock.post.reset();
   appMock.options.reset();
+  appMock.all.reset();
 };
 
 module.exports = () => expressMock;

--- a/tests/serve.test.js
+++ b/tests/serve.test.js
@@ -339,14 +339,10 @@ describe('serve', () => {
       expect(module.serverless.cli.consoleLog).to.have.been.calledWith(
         '  POST - http://localhost:8000/test/func2path/{testParam}'
       );
-      expect(app.options).to.have.callCount(2);
+      expect(app.options).to.have.callCount(1);
       expect(app.options.firstCall).to.have.been.calledWith(
         '/test/func1path',
         testHandlerCors
-      );
-      expect(app.options.secondCall).to.have.been.calledWith(
-        '/test/func2path/:testParam',
-        testHandlerOptions
       );
     });
 

--- a/tests/serve.test.js
+++ b/tests/serve.test.js
@@ -349,6 +349,42 @@ describe('serve', () => {
         testHandlerOptions
       );
     });
+
+    it('should create express handler for all methods for functions with method "any"', () => {
+      const testFuncsConfs = [
+        {
+          'events': [
+            {
+              'method': 'any',
+              'path': 'func1path',
+              'cors': true,
+            }
+          ],
+          'handler': 'module1.func1handler',
+          'handlerFunc': null,
+          'id': 'func1',
+          'moduleName': 'module1',
+        },
+      ];
+      const testStage = 'test';
+      module.options.stage = testStage;
+      const testHandlerBase = 'testHandlerBase';
+      const testHandlerCors = 'testHandlerCors';
+      const testHandlerOptions = 'testHandlerOptions';
+      module._handlerBase = sinon.stub().returns(testHandlerBase);
+      module._optionsHandler = testHandlerOptions;
+      module._handlerAddCors = sinon.stub().returns(testHandlerCors);
+      const app = module._newExpressApp(testFuncsConfs);
+      expect(app.all).to.have.callCount(1);
+      expect(app.all).to.have.been.calledWith(
+        '/test/func1path',
+        testHandlerCors
+      );
+      expect(module.serverless.cli.consoleLog).to.have.been.calledWith(
+        '  ANY - http://localhost:8000/test/func1path'
+      );
+      expect(app.options).to.have.callCount(0);
+    });
   });
 
   describe('serve method', () => {


### PR DESCRIPTION
```yaml
functions:
  foo:
    handler: handler.foo
    events:
      - http:
          path: '/foo'
          method: any
```

> **ANY Method** – Instead of specifying individual behaviors for each HTTP method (GET, POST, PUT, and so forth) you can now use the catch-all ANY method to define the same integration behavior for all requests.

source: https://aws.amazon.com/blogs/aws/api-gateway-update-new-features-simplify-api-development/

Supplement #80 with covering test. 
And...⚠️  second commit also prevent OPTIONS handlers to always be created, but instead only create handler when `cors: true` is set. From my test this would be more close to AWS, even if express has some default automatic OPTIONS handlers (see https://github.com/expressjs/express/issues/2246). [needs-discussion]?