### PR TITLE
Load all environment vars before trying to require any files.

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -16,8 +16,6 @@ module.exports = {
     if (purge) {
       utils.purgeCache(handlerFilePath);
     }
-    //set environment before requiring, as imported modules will be immediately
-    this.setEnvironmentVars(functionId);
     const module = require(handlerFilePath);
     const functionObjectPath = handler.slice(1);
     let func = module;

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -20,6 +20,12 @@ module.exports = {
           throw err;
         }
         const loadedModules = [];
+        // We need to set all environments before requiring any handlers, as
+        // imported modules may be in a single file and immediately require
+        // their environment.
+        for (let funcConf of funcConfs) {
+          this.setEnvironmentVars(funcConf.id);
+        }
         for (let funcConf of funcConfs) {
           funcConf.handlerFunc = this.loadHandler(
             stats,


### PR DESCRIPTION
Multiple functions may share a single file and may immediately depend on the environment.

Closes #99.