### PR TITLE
Update the serverless-offline startup hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ class ServerlessWebpack {
         .then(this.validate)
         .then(this.serve),
 
-      'before:offline:start': () => BbPromise.bind(this)
+      'before:offline:start:init': () => BbPromise.bind(this)
         .then(this.validate)
         .then(this.wpwatch),
     };


### PR DESCRIPTION
I'm having trouble with the serverless-offline startup hooks in the latest version of serverless-offilne. It seems like you have to bind to the `offline:start:init` event in order to have things boot properly into the serverless-offline cycle.