### PR TITLE
Update CORS to use allowed headers from yml

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -53,8 +53,8 @@ module.exports = {
         let handler = this._handlerBase(funcConf, httpEvent);
         let optionsHandler = this._optionsHandler;
         if (httpEvent.cors) {
-          handler = this._handlerAddCors(handler);
-          optionsHandler = this._handlerAddCors(optionsHandler);
+          handler = this._handlerAddCors(handler, httpEvent.cors.headers);
+          optionsHandler = this._handlerAddCors(optionsHandler, httpEvent.cors.headers);
         }
         app.options(path, optionsHandler);
         app[method](
@@ -92,11 +92,12 @@ module.exports = {
     return this.options.port || 8000;
   },
 
-  _handlerAddCors(handler) {
+  _handlerAddCors(handler, headers) {
+    const headString = headers ? headers.join(',') : 'Authorization,Content-Type,x-amz-date,x-amz-security-token';
     return (req, res, next) => {
       res.header('Access-Control-Allow-Origin', '*');
       res.header('Access-Control-Allow-Methods', 'GET,PUT,HEAD,PATCH,POST,DELETE,OPTIONS');
-      res.header('Access-Control-Allow-Headers', 'Authorization,Content-Type,x-amz-date,x-amz-security-token');
+      res.header('Access-Control-Allow-Headers', headString);
       handler(req, res, next);
     };
   },


### PR DESCRIPTION
When using additional custom CORS headers in Serverless, the local `serverless webpack serve` command does not allow those headers when developing locally. This fixes that.