### PR TITLE
Fixes #107 Hook on "deploy function" command

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,6 +99,15 @@ class ServerlessWebpack {
       'after:deploy:createDeploymentArtifacts': () => BbPromise.bind(this)
         .then(this.cleanup),
 
+      // This hook is exposed by SLS' deploy function command
+      'before:deploy:function:packageFunction': () => BbPromise.bind(this)
+        .then(this.validate)
+        .then(this.compile)
+        .then(this.packExternalModules),
+
+      'after:deploy:function:packageFunction': () => BbPromise.bind(this)
+        .then(this.cleanup),
+
       'webpack:validate': () => BbPromise.bind(this)
         .then(this.validate),
 


### PR DESCRIPTION
Fixes #107: This fix hooks the webpack plugin onto the Serverless "deploy function" command. Currently the plugin will webpack the service as it would be done with a regular deploy. Then the single selected function is deployed by Serverless.
This makes the whole thing work. However there could be some improvements done later. Maybe _this.options.f_ can be used in this case to restrict the webpack run to create only the selected function entry point. But finding that would not be trivial.
I suggest to approve this solution on the first hand and handle the rest as improvement.