### PR TITLE
Apply serverless-webpack when use deploy function command

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,6 +99,11 @@ class ServerlessWebpack {
       'after:deploy:createDeploymentArtifacts': () => BbPromise.bind(this)
         .then(this.cleanup),
 
+      'before:deploy:function:initialize': () => BbPromise.bind(this)
+        .then(this.validate)
+        .then(this.compile)
+        .then(this.packExternalModules),
+
       'webpack:validate': () => BbPromise.bind(this)
         .then(this.validate),
 


### PR DESCRIPTION
serverless-webpack isn't used when deploying only a function