### PR TITLE
sls webpack serve / Fix Response not returning Headers

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -122,6 +122,7 @@ module.exports = {
         }
 
         if (isLambdaProxyIntegration) {
+          if (resp.headers) res.set(resp.headers);
           res.status(resp.statusCode || 200).send(resp.body);
         } else {
           res.status(200).send(resp);


### PR DESCRIPTION
AWS Lamda supports setting Headers of Response

Use this to test the change https://github.com/elastic-coders/serverless-webpack/issues/84#issuecomment-287801245
