### PR TITLE
Print webpack compile results

### DIFF
--- a/lib/wpwatch.js
+++ b/lib/wpwatch.js
@@ -14,7 +14,7 @@ module.exports = {
         }
 
         if (stats) {
-            console.log("Webpack rebuilt");
+            console.log(stats.toString());
         }
       });
 


### PR DESCRIPTION
As it is, this plugin hides errors during watch. This shows them.