### PR TITLE
Add support for webpack configuration in TypeScript format

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,15 @@ class ServerlessWebpack {
     this.serverless = serverless;
     this.options = options;
 
+    if (
+      this.serverless.service
+      && this.serverless.service.custom
+      && this.serverless.service.custom.webpack
+      && this.serverless.service.custom.webpack.endsWith('.ts')
+    ) {
+      require('ts-node/register');
+    }
+
     Object.assign(
       this,
       validate,

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "body-parser": "^1.15.2",
     "express": "^4.14.0",
     "fs-extra": "^0.26.7",
-    "npm-programmatic": "0.0.5"
+    "npm-programmatic": "0.0.5",
+    "ts-node": "^3.2.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
To add support for webpack configuration in TypeScript format (e.g. webpack.config.ts), there's an existing package `ts-node` which just does the magic.

Webpack uses this method also internally, if specifying configuration file to webpack by using `webpack --config webpack.config.ts`. But since `serverless-webpack` does require the configuration  by using a  "require", `ts-node` needs to be required to support on-the-fly `.ts` -file requires.