### PR TITLE
Add lifecycle hook for serverless offline start

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,6 +123,11 @@ class ServerlessWebpack {
       'before:offline:start': () => BbPromise.bind(this)
         .then(this.validate)
         .then(this.wpwatch),
+      
+      'before:offline:start:init': () => BbPromise.bind(this)
+        .then(this.validate)
+        .then(this.wpwatch),
+      
     };
   }
 }


### PR DESCRIPTION
Serverless offline has 2 root commands to start : 
- `serverless offline` which triggers `offline:start` life cycle hook (This is working)
- `serverless offline start` which triggers `offline:start:init` and  `offline:start:end` life cycle hooks (This is NOT working)

The second one is important, because it has an event on start up and on end.
If you want to work with serverless-offline, serverless-webpack and serverless-dynamodb-local. You need to call `sls offline start` which will also stop the db and stop serverless offline