### PR TITLE
Make processed input path absolute

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const wpwatch = require('./lib/wpwatch');
 const cleanup = require('./lib/cleanup');
 const run = require('./lib/run');
 const serve = require('./lib/serve');
-const utils = require('./lib/utils');
+const makePathOptionAbsolute = require('./lib/makePathOptionAbsolute');
 const packExternalModules = require('./lib/packExternalModules');
 
 class ServerlessWebpack {
@@ -25,7 +25,7 @@ class ServerlessWebpack {
       run,
       serve,
       packExternalModules,
-      utils
+      makePathOptionAbsolute
     );
 
     this.commands = {
@@ -93,7 +93,7 @@ class ServerlessWebpack {
       'before:invoke:local:invoke': () => BbPromise.bind(this)
         .then(this.validate)
         .then(this.compile)
-        .then(this.makeProcessedInputPathAbsolutePath),
+        .then(this.makePathOptionAbsolute),
 
       'webpack:validate': () => BbPromise.bind(this)
         .then(this.validate),

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const wpwatch = require('./lib/wpwatch');
 const cleanup = require('./lib/cleanup');
 const run = require('./lib/run');
 const serve = require('./lib/serve');
+const utils = require('./lib/utils');
 const packExternalModules = require('./lib/packExternalModules');
 
 class ServerlessWebpack {
@@ -23,7 +24,8 @@ class ServerlessWebpack {
       cleanup,
       run,
       serve,
-      packExternalModules
+      packExternalModules,
+      utils
     );
 
     this.commands = {
@@ -90,7 +92,8 @@ class ServerlessWebpack {
 
       'before:invoke:local:invoke': () => BbPromise.bind(this)
         .then(this.validate)
-        .then(this.compile),
+        .then(this.compile)
+        .then(this.makeProcessedInputPathAbsolutePath),
 
       'webpack:validate': () => BbPromise.bind(this)
         .then(this.validate),

--- a/lib/makePathOptionAbsolute.js
+++ b/lib/makePathOptionAbsolute.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const BbPromise = require('bluebird');
+const path = require('path');
+
+module.exports = {
+  makePathOptionAbsolute() {
+    const originalPath = this.serverless.config.serverless.processedInput.options.path;
+    if (originalPath) {
+      const absolutePath = path.resolve(originalPath);
+      this.serverless.config.serverless.processedInput.options.path = absolutePath;
+    };
+    return BbPromise.resolve();
+  }
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const BbPromise = require('bluebird');
-const path = require('path');
-
 function guid() {
   function s4() {
     return Math.floor((1 + Math.random()) * 0x10000)
@@ -35,18 +32,8 @@ function searchCache(moduleName, callback) {
   }
 }
 
-function makeProcessedInputPathAbsolutePath() {
-  var originalPath = this.serverless.config.serverless.processedInput.options.path
-  if (originalPath) {
-    var absolutePath = path.resolve(originalPath)
-    this.serverless.config.serverless.processedInput.options.path = absolutePath
-  }
-  return BbPromise.resolve();
-}
-
 module.exports = {
   guid,
   purgeCache,
-  searchCache,
-  makeProcessedInputPathAbsolutePath
+  searchCache
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const BbPromise = require('bluebird');
+const path = require('path');
+
 function guid() {
   function s4() {
     return Math.floor((1 + Math.random()) * 0x10000)
@@ -32,8 +35,18 @@ function searchCache(moduleName, callback) {
   }
 }
 
+function makeProcessedInputPathAbsolutePath() {
+  var originalPath = this.serverless.config.serverless.processedInput.options.path
+  if (originalPath) {
+    var absolutePath = path.resolve(originalPath)
+    this.serverless.config.serverless.processedInput.options.path = absolutePath
+  }
+  return BbPromise.resolve();
+}
+
 module.exports = {
   guid,
   purgeCache,
   searchCache,
+  makeProcessedInputPathAbsolutePath
 };


### PR DESCRIPTION
## What did you implement:

Related: #151

When using the invoke local command with the --path (-p) flag, relative file paths will not be found because serverless will end up looking in the build directory later on. So, this PR ensures that the path is absolute, ensuring it will be found, even if the path was relative.

## How did you implement it:

I added a function in utils.js that gets the --path option if present. It then uses `path.resolve` to resolve it, then assigns it back to serverless config.

## How can we verify it:

Just use `invoke local` with the --path option:

`serverless invoke local -f function_name --path data.json`

## Todos:

- [ ] Write tests
- [ ] Write documentation
- Fix linting errors (not yet implemented)
- Make sure code coverage hasn't dropped (not yet implemented)
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
