### PR TITLE
Change CWD before local invoke and restore it afterwards

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const compile = require('./lib/compile');
 const wpwatch = require('./lib/wpwatch');
 const cleanup = require('./lib/cleanup');
 const run = require('./lib/run');
-const makePathOptionAbsolute = require('./lib/makePathOptionAbsolute');
+const prepareLocalInvoke = require('./lib/prepareLocalInvoke');
 const packExternalModules = require('./lib/packExternalModules');
 const packageModules = require('./lib/packageModules');
 const lib = require('./lib');
@@ -39,7 +39,7 @@ class ServerlessWebpack {
       run,
       packExternalModules,
       packageModules,
-      makePathOptionAbsolute
+      prepareLocalInvoke
     );
 
     this.commands = {
@@ -97,7 +97,7 @@ class ServerlessWebpack {
       'before:invoke:local:invoke': () => BbPromise.bind(this)
         .then(this.validate)
         .then(this.compile)
-        .then(this.makePathOptionAbsolute),
+        .then(this.prepareLocalInvoke),
 
       'after:invoke:local:invoke': () => BbPromise.bind(this)
         .then(() => {

--- a/lib/makePathOptionAbsolute.js
+++ b/lib/makePathOptionAbsolute.js
@@ -13,11 +13,15 @@ module.exports = {
     }
 
     // Set service path to compiled code for local invoke.
+    this.originalServicePath = this.serverless.config.servicePath;
     if (_.get(this.serverless, 'service.package.individually')) {
       this.serverless.config.servicePath = path.join(this.webpackOutputPath, this.options.function);
     } else {
       this.serverless.config.servicePath = path.join(this.webpackOutputPath, 'service');
     }
+
+    // Set service path as CWD to allow accessing bundled files correctly
+    process.chdir(this.serverless.config.servicePath);
 
     return BbPromise.resolve();
   }

--- a/lib/prepareLocalInvoke.js
+++ b/lib/prepareLocalInvoke.js
@@ -5,7 +5,7 @@ const path = require('path');
 const _ = require('lodash');
 
 module.exports = {
-  makePathOptionAbsolute() {
+  prepareLocalInvoke() {
     const originalPath = this.serverless.config.serverless.processedInput.options.path;
     if (originalPath) {
       const absolutePath = path.resolve(originalPath);

--- a/lib/run.js
+++ b/lib/run.js
@@ -18,13 +18,8 @@ module.exports = {
       }
 
       BbPromise.try(() => {
-        // Currently the plugin bends the service path to point to the webpack
-        // directory in the compile step. This has to be reverted here so that
-        // the webpack configuration can be found.
-        // We have to think about changing the whole servicePath approach, so
-        // that the plugin can use the given one and does not change it while
-        // processing.
         if (this.originalServicePath) {
+          process.chdir(this.originalServicePath);
           this.serverless.config.servicePath = this.originalServicePath;
         }
 

--- a/tests/run.test.js
+++ b/tests/run.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const BbPromise = require('bluebird');
+const _ = require('lodash');
 const chai = require('chai');
 const sinon = require('sinon');
 const mockery = require('mockery');
@@ -10,6 +11,7 @@ const makeUtilsMock = require('./utils.mock');
 
 chai.use(require('chai-as-promised'));
 chai.use(require('sinon-chai'));
+
 const expect = chai.expect;
 
 describe('run', () => {
@@ -19,6 +21,7 @@ describe('run', () => {
   let baseModule;
   let serverless;
   let module;
+  let chdirStub;
 
   before(() => {
     sandbox = sinon.sandbox.create();
@@ -46,10 +49,12 @@ describe('run', () => {
       consoleLog: sandbox.stub()
     };
 
-    module = Object.assign({
+    module = _.assign({
       serverless,
       options: {},
     }, baseModule);
+
+    chdirStub = sandbox.stub(process, 'chdir');
   });
 
   afterEach(() => {
@@ -59,12 +64,6 @@ describe('run', () => {
 
   describe('watch', () => {
     let spawnStub;
-
-    const testEvent = {};
-    const testContext = {};
-    const testStats = {};
-    const testFunctionId = 'testFunctionId';
-    const testFunctionResult = 'testFunctionResult';
 
     beforeEach(() => {
       spawnStub = sandbox.stub(serverless.pluginManager, 'spawn');
@@ -106,6 +105,8 @@ describe('run', () => {
 
       watch();
       expect(serverless.config.servicePath).to.equal('originalPath');
+      expect(chdirStub).to.have.been.calledOnce;
+      expect(chdirStub).to.have.been.calledWithExactly('originalPath');
     });
   });
 });


### PR DESCRIPTION
## What did you implement:

Closes #180 

## How did you implement it:

Change the CWD to the compilation base directory just before `serverless invoke local` is started. This makes sure that bundled files (e.g. by using the `file-loader`) can be loaded correctly. This correctly the execution environment to be exactly the same as within AWS Lambda.

## How can we verify it:

See #180 

## Todos:

- Fix linting errors (not yet implemented)
- Make sure code coverage hasn't dropped (not yet implemented)
- [x] Provide verification config / commands / resources
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
