### PR TITLE
Allow setting of maxBuffer for packing external modules (v3)

### DIFF
--- a/lib/packExternalModules.js
+++ b/lib/packExternalModules.js
@@ -105,6 +105,7 @@ module.exports = {
       const start = _.now();
       npm.install(compositeModules, {
         cwd: compositeModulePath,
+        maxBuffer: this.serverless.service.custom.packExternalModulesMaxBuffer || 200 * 1024,
         save: true
       }).then(() => {
         this.options.verbose && this.serverless.cli.log(`Package took [${_.now() - start} ms]`);    // eslint-disable-line promise/always-return

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "fs-extra": "^0.26.7",
     "glob": "^7.1.2",
     "lodash": "^4.17.4",
-    "npm-programmatic": "0.0.5",
+    "npm-programmatic": "^0.0.7",
     "semver": "^5.4.1",
     "ts-node": "^3.2.0"
   },


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
2. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
Allow setting of maxBuffer for packing external modules. New version of https://github.com/elastic-coders/serverless-webpack/pull/96

<!--
Briefly describe the feature if no issue exists for this PR. If possible only
submit PRs for existing issues. If the PR is trivial (like doc changes or simple
code fixes) it can be submitted without a related issue, but as soon as it adds
or changes functionality, a related issue should be present.
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Step by step description, how to verify
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- Fix linting errors (not yet implemented)
- Make sure code coverage hasn't dropped (not yet implemented)
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
