### PR TITLE
Use path where needed to make unit tests on Windows pass.

### DIFF
--- a/tests/packExternalModules.test.js
+++ b/tests/packExternalModules.test.js
@@ -76,7 +76,7 @@ describe('packExternalModules', () => {
     sandbox.restore();
   });
 
-  describe('packageModules()', () => {
+  describe('packExternalModules()', () => {
     it('should do nothing if webpackIncludeModules is not set', () => {
       _.unset(serverless, 'service.custom.webpackIncludeModules');
       return expect(module.packExternalModules({ stats: [] })).to.eventually.deep.equal({ stats: [] })
@@ -154,7 +154,7 @@ describe('packExternalModules', () => {
           'bluebird@^3.4.0'
         ],
         {
-          cwd: 'outputPath/dependencies',
+          cwd: path.join('outputPath', 'dependencies'),
           maxBuffer: 204800,
           save: true
         }),

--- a/tests/packageModules.test.js
+++ b/tests/packageModules.test.js
@@ -3,6 +3,7 @@
 const BbPromise = require('bluebird');
 const _ = require('lodash');
 const chai = require('chai');
+const path = require('path');
 const sinon = require('sinon');
 const mockery = require('mockery');
 const Serverless = require('serverless');
@@ -134,10 +135,12 @@ describe('packageModules', () => {
       fsMock._streamMock.on.withArgs('close').yields();
       fsMock._statMock.isDirectory.returns(false);
 
+      const expectedArtifactPath = path.join('.serverless', 'test-service.zip');
+
       return expect(module.packageModules(stats)).to.be.fulfilled
       .then(() => BbPromise.all([
-        expect(func1).to.have.a.nested.property('package.artifact').that.equals('.serverless/test-service.zip'),
-        expect(func2).to.have.a.nested.property('package.artifact').that.equals('.serverless/test-service.zip'),
+        expect(func1).to.have.a.nested.property('package.artifact').that.equals(expectedArtifactPath),
+        expect(func2).to.have.a.nested.property('package.artifact').that.equals(expectedArtifactPath),
       ]));
     });
 
@@ -205,8 +208,8 @@ describe('packageModules', () => {
 
       return expect(module.packageModules(stats)).to.be.fulfilled
       .then(() => BbPromise.all([
-        expect(func1).to.have.a.nested.property('package.artifact').that.equals('.serverless/func1.zip'),
-        expect(func2).to.have.a.nested.property('package.artifact').that.equals('.serverless/func2.zip'),
+        expect(func1).to.have.a.nested.property('package.artifact').that.equals(path.join('.serverless', 'func1.zip')),
+        expect(func2).to.have.a.nested.property('package.artifact').that.equals(path.join('.serverless', 'func2.zip')),
       ]));
     });
 
@@ -252,20 +255,22 @@ describe('packageModules', () => {
       fsMock._streamMock.on.withArgs('close').yields();
       fsMock._statMock.isDirectory.returns(false);
 
+      const expectedArtifactPath = path.join('.serverless', 'test-service.zip');
+
       return BbPromise.each([ '1.18.1', '2.17.0', '10.15.3', ], version => {
         getVersionStub.returns(version);
         return expect(module.packageModules(stats)).to.be.fulfilled
         .then(() => BbPromise.all([
-          expect(func1).to.have.a.nested.property('package.artifact').that.equals('.serverless/test-service.zip'),
-          expect(func2).to.have.a.nested.property('package.artifact').that.equals('.serverless/test-service.zip'),
+          expect(func1).to.have.a.nested.property('package.artifact').that.equals(expectedArtifactPath),
+          expect(func2).to.have.a.nested.property('package.artifact').that.equals(expectedArtifactPath),
         ]));
       })
       .then(() => BbPromise.each([ '1.17.0', '1.16.0-alpha', '1.15.3', ], version => {
         getVersionStub.returns(version);
         return expect(module.packageModules(stats)).to.be.fulfilled
         .then(() => BbPromise.all([
-          expect(func1).to.have.a.nested.property('artifact').that.equals('.serverless/test-service.zip'),
-          expect(func2).to.have.a.nested.property('artifact').that.equals('.serverless/test-service.zip'),
+          expect(func1).to.have.a.nested.property('artifact').that.equals(expectedArtifactPath),
+          expect(func2).to.have.a.nested.property('artifact').that.equals(expectedArtifactPath),
         ]));
       }));
     });

--- a/tests/validate.test.js
+++ b/tests/validate.test.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const chai = require('chai');
 const sinon = require('sinon');
 const mockery = require('mockery');
+const path = require('path');
 const Serverless = require('serverless');
 const makeFsExtraMock = require('./fs-extra.mock');
 
@@ -104,7 +105,7 @@ describe('validate', () => {
     return module
       .validate()
       .then(() => expect(module.webpackConfig.output).to.eql({
-        path: `${testServicePath}/${testOptionsOut}/service`,
+        path: path.join(testServicePath, testOptionsOut, 'service'),
         filename: 'filename',
       }));
   });
@@ -135,7 +136,7 @@ describe('validate', () => {
         .validate()
         .then(() => expect(module.webpackConfig.output).to.eql({
           libraryTarget: 'commonjs',
-          path: `${testServicePath}/.webpack/service`,
+          path: path.join(testServicePath, '.webpack', 'service'),
           filename: '[name].js',
         }));
     });
@@ -152,7 +153,7 @@ describe('validate', () => {
         .validate()
         .then(() => expect(module.webpackConfig.output).to.eql({
           libraryTarget: 'commonjs',
-          path: `${testServicePath}/.webpack/service`,
+          path: path.join(testServicePath, '.webpack', 'service'),
           filename: '[name].js',
         }));
     });
@@ -166,7 +167,7 @@ describe('validate', () => {
         .validate()
         .then(() => expect(module.webpackConfig.output).to.eql({
           libraryTarget: 'commonjs',
-          path: `${testServicePath}/.webpack/service`,
+          path: path.join(testServicePath, '.webpack', 'service'),
           filename: '[name].js',
         }));
     });
@@ -176,7 +177,7 @@ describe('validate', () => {
     it('should load a webpack config from file if `custom.webpack` is a string', () => {
       const testConfig = 'testconfig';
       const testServicePath = 'testpath';
-      const requiredPath = `${testServicePath}/${testConfig}`;
+      const requiredPath = path.join(testServicePath, testConfig);
       module.serverless.config.servicePath = testServicePath;
       module.serverless.service.custom.webpack = testConfig;
       serverless.utils.fileExistsSync = sinon.stub().returns(true);
@@ -206,7 +207,7 @@ describe('validate', () => {
     it('should load a default file if no custom config is provided', () => {
       const testConfig = 'webpack.config.js';
       const testServicePath = 'testpath';
-      const requiredPath = `${testServicePath}/${testConfig}`;
+      const requiredPath = path.join(testServicePath, testConfig);
       module.serverless.config.servicePath = testServicePath;
       serverless.utils.fileExistsSync = sinon.stub().returns(true);
       const loadedConfig = {


### PR DESCRIPTION
## What did you implement:

Closes #145 

## How did you implement it:

Use the `path` module to create paths used in unit tests. This makes sure that the native path separators are used in all expectations.
Fixed wrong test description.

## How can we verify it:

Run `npm test` on Windows (e.g. Git bash).

## Todos:

- [x] Write tests
- ~~[ ] Write documentation~~
- Fix linting errors (not yet implemented)
- Make sure code coverage hasn't dropped (not yet implemented)
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
