### PR TITLE
Set offline location parameter automatically.

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const wpwatch = require('./lib/wpwatch');
 const cleanup = require('./lib/cleanup');
 const run = require('./lib/run');
 const prepareLocalInvoke = require('./lib/prepareLocalInvoke');
+const prepareOfflineInvoke = require('./lib/prepareOfflineInvoke');
 const packExternalModules = require('./lib/packExternalModules');
 const packageModules = require('./lib/packageModules');
 const lib = require('./lib');
@@ -39,7 +40,8 @@ class ServerlessWebpack {
       run,
       packExternalModules,
       packageModules,
-      prepareLocalInvoke
+      prepareLocalInvoke,
+      prepareOfflineInvoke
     );
 
     this.commands = {
@@ -125,12 +127,12 @@ class ServerlessWebpack {
         .then(() => BbPromise.reject(new this.serverless.classes.Error('serve has been removed. Use serverless-offline instead.'))),
 
       'before:offline:start': () => BbPromise.bind(this)
-        .then(this.validate)
+        .then(this.prepareOfflineInvoke)
         .then(this.compile)
         .then(this.wpwatch),
 
       'before:offline:start:init': () => BbPromise.bind(this)
-        .then(this.validate)
+        .then(this.prepareOfflineInvoke)
         .then(this.compile)
         .then(this.wpwatch),
 

--- a/lib/prepareOfflineInvoke.js
+++ b/lib/prepareOfflineInvoke.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const _ = require('lodash');
+const path = require('path');
+
+/**
+ * Special settings for use with serverless-offline.
+ */
+
+module.exports = {
+  prepareOfflineInvoke() {
+
+    // Use service packaging for compile
+    _.set(this.serverless, 'service.package.individually', false);
+
+    return this.validate()
+    .then(() => {
+      // Set offline location automatically if not set manually
+      if (!this.options.location && !_.get(this.serverless, 'service.custom.serverless-offline.location')) {
+        _.set(this.serverless, 'service.custom.serverless-offline.location',
+          path.relative(this.serverless.config.servicePath, path.join(this.webpackOutputPath, 'service'))
+        );
+      }
+      return null;
+    });
+  }
+};

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -15,7 +15,8 @@ const _ = require('lodash');
 const preferredExtensions = [
   '.js',
   '.ts',
-  '.jsx'
+  '.jsx',
+  '.tsx'
 ];
 
 module.exports = {

--- a/lib/wpwatch.js
+++ b/lib/wpwatch.js
@@ -9,14 +9,14 @@ module.exports = {
 
     const compiler = webpack(this.webpackConfig);
     compiler.watch({}, (err, stats) => {
-        if (err) {
-          throw err;
-        }
+      if (err) {
+        throw err;
+      }
 
-        if (stats) {
-            console.log(stats.toString());
-        }
-      });
+      if (stats) {
+        console.log(stats.toString());   // eslint-disable-line no-console
+      }
+    });
 
     return BbPromise.resolve();
   },


### PR DESCRIPTION
## What did you implement:

Closes #191 

## How did you implement it:

The serverless-offline hook now sets the proper `location` option automatically if it not set manually by the user. Additionally serverless-offline disables individual packaging now, to make sure that all endpoints are available. This does not have any effect on the standard serverless deployment. It is only switched for offline.

## How can we verify it:

Use an ELM project or any other project, Do not set a location anywhere and run `serverless offline` or `serverless offline start`.

## Todos:

- [ ] Write tests
- [ ] Write documentation
- Fix linting errors (not yet implemented)
- Make sure code coverage hasn't dropped (not yet implemented)
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
