### PR TITLE
Set artifact file path for the Google provider.

### DIFF
--- a/lib/packageModules.js
+++ b/lib/packageModules.js
@@ -100,6 +100,10 @@ module.exports = {
           const func = this.serverless.service.getFunction(funcName);
           setArtifactPath.call(this, func, path.relative(this.serverless.config.servicePath, artifacts[0]));
         });
+        // For Google set the service artifact path
+        if (_.get(this.serverless, 'service.provider.name') === 'google') {
+          _.set(this.serverless, 'service.package.artifact', path.relative(this.serverless.config.servicePath, artifacts[0]));
+        }
       }
 
       return null;

--- a/tests/validate.test.js
+++ b/tests/validate.test.js
@@ -318,6 +318,18 @@ describe('validate', () => {
         },
       };
 
+      const testFunctionsGoogleConfig = {
+        func1: {
+          handler: 'func1handler',
+          events: [{
+            http: {
+              method: 'get',
+              path: 'func1path',
+            },
+          }],
+        },
+      };
+
       it('should expose all functions if `options.function` is not defined', () => {
         const testOutPath = 'test';
         const testConfig = {
@@ -370,6 +382,33 @@ describe('validate', () => {
 
           expect(lib.entries).to.deep.equal(expectedLibEntries);
           expect(globSyncStub).to.have.been.calledOnce;
+          expect(serverless.cli.log).to.not.have.been.called;
+          return null;
+        });
+      });
+
+      it('should ignore entry points for the Google provider', () => {
+        const testOutPath = 'test';
+        const testFunction = 'func1';
+        const testConfig = {
+          entry: './index.js',
+          target: 'node',
+          output: {
+            path: testOutPath,
+            filename: 'index.js'
+          },
+        };
+        sandbox.stub(module.serverless, 'service.provider.name').value('google');
+        module.serverless.service.custom.webpack = testConfig;
+        module.serverless.service.functions = testFunctionsGoogleConfig;
+        module.options.function = testFunction;
+        globSyncStub.returns([]);
+        return expect(module.validate()).to.be.fulfilled
+        .then(() => {
+          const lib = require('../lib/index');
+
+          expect(lib.entries).to.deep.equal({});
+          expect(globSyncStub).to.not.have.been.called;
           expect(serverless.cli.log).to.not.have.been.called;
           return null;
         });


### PR DESCRIPTION
## What did you implement:

Closes #199 

## How did you implement it:

If the Google provider is active, the plugin now sets the path to the packaged service artifact as service artifact path. This lets the Google provider plugin successfully run its compile step.

## How can we verify it:

Run `serverless package` with a Google project that has the webpack plugin enabled.

## Todos:

- [x] Write tests
- [ ] Write documentation
- Fix linting errors (not yet implemented)
- Make sure code coverage hasn't dropped (not yet implemented)
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
