### PR TITLE
Use package.disable to prevent packaging with SLS <= 1.17.

### DIFF
--- a/lib/packageModules.js
+++ b/lib/packageModules.js
@@ -8,12 +8,14 @@ const fs = require('fs');
 const glob = require('glob');
 const semver = require('semver');
 
-function setArtifactPath(func, artifactPath) {
+function setArtifactPath(funcName, func, artifactPath) {
   const version = this.serverless.getVersion();
 
   // Serverless changed the artifact path location in version 1.18
   if (semver.lt(version, '1.18.0')) {
     func.artifact = artifactPath;
+    func.package = _.assign({}, func.package, { disable: true });
+    this.serverless.cli.log(`${funcName} is packaged by the webpack plugin. Ignore messages from SLS.`);
   } else {
     func.package = {
       artifact: artifactPath,
@@ -87,7 +89,7 @@ module.exports = {
         this.serverless.cli.log(`Zip ${_.isEmpty(entryFunction) ? 'service' : 'function'}: ${modulePath} [${_.now() - startZip} ms]`))
       .then(artifactPath => {
         if (_.get(this.serverless, 'service.package.individually')) {
-          setArtifactPath.call(this, entryFunction.func, path.relative(this.serverless.config.servicePath, artifactPath));
+          setArtifactPath.call(this, entryFunction.funcName, entryFunction.func, path.relative(this.serverless.config.servicePath, artifactPath));
         }
         return artifactPath;
       });
@@ -98,7 +100,7 @@ module.exports = {
         const allFunctionNames = this.serverless.service.getAllFunctions();
         _.forEach(allFunctionNames, funcName => {
           const func = this.serverless.service.getFunction(funcName);
-          setArtifactPath.call(this, func, path.relative(this.serverless.config.servicePath, artifacts[0]));
+          setArtifactPath.call(this, funcName, func, path.relative(this.serverless.config.servicePath, artifacts[0]));
         });
         // For Google set the service artifact path
         if (_.get(this.serverless, 'service.provider.name') === 'google') {

--- a/tests/packageModules.test.js
+++ b/tests/packageModules.test.js
@@ -321,6 +321,8 @@ describe('packageModules', () => {
         .then(() => BbPromise.all([
           expect(func1).to.have.a.nested.property('artifact').that.equals(expectedArtifactPath),
           expect(func2).to.have.a.nested.property('artifact').that.equals(expectedArtifactPath),
+          expect(func1).to.have.a.nested.property('package.disable').that.is.true,
+          expect(func2).to.have.a.nested.property('package.disable').that.is.true,
         ]));
       }));
     });


### PR DESCRIPTION
## What did you implement:

Closes #206 

## How did you implement it:

Use `function.package.disable` to prevent packaging with Serverless. This seems to be the only way to skip packaging with SLS <= 1.17. Added a message to let the user know that packaging happens although Serverless tells about diabled packaging.

## How can we verify it:

Use SLS 1.17.0 and package or deploy a service. The packages should be the ones that the plugin created and not the whole service directory package from Serverless.

## Todos:

- [x] Write tests
- [ ] Write documentation
- Fix linting errors (not yet implemented)
- Make sure code coverage hasn't dropped (not yet implemented)
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
